### PR TITLE
CSV Export Improvements

### DIFF
--- a/components/class-m-chart-admin.php
+++ b/components/class-m-chart-admin.php
@@ -150,12 +150,11 @@ class M_Chart_Admin {
 	 * @param object the WP post object as returned by the metabox API
 	 */
 	public function csv_meta_box( $post ) {
-		$export_url = admin_url( 'admin-ajax.php?action=m_chart_export_csv&post_id=' . absint( $post->ID ) );
 		require_once __DIR__ . '/templates/csv-meta-box.php';
 	}
 
 	/**
-	 * Inserts a CSV Import form into the footer when editing charts
+	 * Insert CSV Import and Export forms into the footer when editing charts
 	 */
 	public function admin_footer() {
 		$screen = get_current_screen();
@@ -166,6 +165,11 @@ class M_Chart_Admin {
 		?>
 		<form id="<?php echo esc_attr( $this->get_field_id( 'csv-import-form' ) ); ?>" style="display: none;">
 			<input type="file" name="import_csv_file" id="<?php echo esc_attr( $this->get_field_id( 'csv-file' ) ); ?>" class="hide" />
+		</form>
+		<form action="<?php echo esc_url( admin_url( 'admin-ajax.php?action=m_chart_export_csv' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'csv-export-form' ) ); ?>" style="display: none;" method="post">
+			<input type="hidden" name="post_id" value="" id="<?php echo esc_attr( $this->get_field_id( 'csv-post-id' ) ); ?>" />
+			<input type="hidden" name="data" value="" id="<?php echo esc_attr( $this->get_field_id( 'csv-data' ) ); ?>" />
+			<input type="hidden" name="title" value="" id="<?php echo esc_attr( $this->get_field_id( 'csv-title' ) ); ?>" />
 		</form>
 		<?php
 	}
@@ -403,12 +407,22 @@ class M_Chart_Admin {
 	 * Converts data array into CSV outputs it to the browser
 	 */
 	public function ajax_export_csv() {
-		if ( ! is_numeric( $_GET['post_id'] )  || ! current_user_can( 'edit_post', absint( $_GET['post_id'] ) ) ) {
+		// Purposely using $_REQUEST here since this method can work via a GET and POST request
+		// POST requests are used when passing the data value since it's too big to pass via GET
+		if ( ! is_numeric( $_REQUEST['post_id'] )  || ! current_user_can( 'edit_post', absint( $_REQUEST['post_id'] ) ) ) {
 			wp_die( 'Unauthorized access', 'You do not have permission to do that', array( 'response' => 401 ) );
 		}
 
-		$post = get_post( absint( $_GET['post_id'] ) );
-		$data = m_chart()->get_post_meta( $post->ID, 'data' );
+		$post = get_post( absint( $_REQUEST['post_id'] ) );
+
+		// If the user passed a data value in their request we'll use it after validation
+		if ( isset( $_POST['data'] ) && isset( $_POST['title'] ) ) {
+			$data      = m_chart()->validate_data( json_decode( stripslashes( $_POST['data'] ) ) );
+			$file_name = sanitize_title( $_POST['title'] );
+		} else {
+			$data      = m_chart()->get_post_meta( $post->ID, 'data' );
+			$file_name = sanitize_title( get_the_title( $post->ID ) );
+		}
 
 		if ( empty( $data ) ) {
 			return;
@@ -417,7 +431,7 @@ class M_Chart_Admin {
 		require_once __DIR__ . '/external/parsecsv/parsecsv.lib.php';
 		$parse_csv = new parseCSV();
 
-		$parse_csv->output( sanitize_title( get_the_title( $post->ID ) ) . '.csv', $data );
+		$parse_csv->output( $file_name . '.csv', $data );
 		die;
 	}
 

--- a/components/class-m-chart-admin.php
+++ b/components/class-m-chart-admin.php
@@ -419,7 +419,8 @@ class M_Chart_Admin {
 		if ( isset( $_POST['data'] ) && isset( $_POST['title'] ) ) {
 			$data      = m_chart()->validate_data( json_decode( stripslashes( $_POST['data'] ) ) );
 			$file_name = sanitize_title( $_POST['title'] );
-		} else {
+		}
+		else {
 			$data      = m_chart()->get_post_meta( $post->ID, 'data' );
 			$file_name = sanitize_title( get_the_title( $post->ID ) );
 		}

--- a/components/class-m-chart.php
+++ b/components/class-m-chart.php
@@ -264,7 +264,7 @@ class M_Chart {
 					$chart_meta[ $field ] = (bool) $meta[ $field ];
 				} elseif ( 'height' == $field ) {
 					$chart_meta[ $field ] = absint( $meta[ $field ] );
-					
+
 					if ( $chart_meta[ $field ] > 900 ) {
 						$chart_meta[ $field ] = 900;
 					} else if ( $chart_meta[ $field ] < 300 ) {
@@ -286,13 +286,28 @@ class M_Chart {
 		}
 
 		// Validate the data array
-		if ( is_array( $chart_meta['data'] ) ) {
-			array_walk_recursive( $chart_meta['data'], function( &$value ) {
-				$value = wp_filter_nohtml_kses( $value );
-			});
-		}
+		$chart_meta['data'] = $this->validate_data( $chart_meta['data'] );
 
 		return $chart_meta;
+	}
+
+	/**
+	 * Runs all of the raw data array values through wp_filter_nohtml_kses
+	 *
+	 * @param array $data an array of data as passed by the user
+	 *
+	 * @return array of validated data
+	 */
+	public function validate_data( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		array_walk_recursive( $data, function( &$value ) {
+			$value = wp_filter_nohtml_kses( $value );
+		});
+
+		return $data;
 	}
 
 	/**

--- a/components/class-m-chart.php
+++ b/components/class-m-chart.php
@@ -298,17 +298,23 @@ class M_Chart {
 	 *
 	 * @return array of validated data
 	 */
-	public function validate_data( $data ) {
+	function validate_data( $data ) {
 		if ( ! is_array( $data ) ) {
-			return $data;
+			return wp_filter_nohtml_kses( $data );
 		}
 
-		array_walk_recursive( $data, function( &$value ) {
-			$value = wp_filter_nohtml_kses( $value );
-		});
+        foreach ( $data as $key => $value ) {
+            if ( is_array( $value ) ) {
+                $data[ $key ] = $this->validate_data( $value );
+            }
+            else {
+                $data[ $key ] = wp_filter_nohtml_kses( $value );
+            }
+        }
 
-		return $data;
-	}
+        return $data;
+    }
+
 
 	/**
 	 * Hook to save_post action and save chart related post meta

--- a/components/js/m-chart-admin.js
+++ b/components/js/m-chart-admin.js
@@ -55,6 +55,7 @@ var m_chart_admin = {
 		});
 
 		this.handle_csv_import();
+		this.handle_csv_export();
 		this.watch_for_chart_changes();
 	};
 
@@ -199,6 +200,21 @@ var m_chart_admin = {
 				$select.removeClass( 'hide' );
 				$file_import.addClass( 'hide' );
 			});
+		});
+	};
+
+	// Handle CSV export functionality
+	m_chart_admin.handle_csv_export = function() {
+		$( document.getElementById( 'm-chart-csv' ) ).find( '.export a' ).on( 'click', function( event ) {
+			event.preventDefault();
+
+			var $form = $( document.getElementById( 'm-chart-csv-export-form' ) );
+
+			$( document.getElementById( 'm-chart-csv-post-id' ) ).val( m_chart_admin.post_id );
+			$( document.getElementById( 'm-chart-csv-data' ) ).val( JSON.stringify( m_chart_admin.$spreadsheet.getData() ) );
+			$( document.getElementById( 'm-chart-csv-title' ) ).val( m_chart_admin.$title_input.attr( 'value' ) );
+
+			$form.trigger( 'submit' );
 		});
 	};
 

--- a/components/templates/csv-meta-box.php
+++ b/components/templates/csv-meta-box.php
@@ -1,5 +1,5 @@
 <div class="export">
-	<a href="<?php echo esc_url( $export_url ); ?>" title="<?php esc_attr_e( 'Export CSV', 'm-chart' ); ?>" class="button"><?php esc_html_e( 'Export', 'm-chart' ); ?></a>
+	<a href="#export-csv" title="<?php esc_attr_e( 'Export CSV', 'm-chart' ); ?>" class="button"><?php esc_html_e( 'Export', 'm-chart' ); ?></a>
 </div>
 <div class="import">
 	<div class="controls">


### PR DESCRIPTION
- It had become strange that the CSV export wasn't being done on the fly anymore
	- i.e. a user could enter data click 'Export' before saving and that data wasn't reflected in the export they requested
- Did this is a way that retainst the old post_id only functionality as I can see that being useful still when not inside of a chart edit form.
- Also moved the data array validation outside of `validate_post_meta` so we can ensure a clean data array before serving the user a CSV export file.