### PR TITLE
Wordpress.org doesn't allow hotlinking anymore

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function( grunt ) {
 					'README.md': 'readme.txt'
 				},
 				options: {
-					screenshot_url: 'http://s-plugins.wordpress.org/m-chart/assets/{screenshot}.png',
+					screenshot_url: 'https://methnen.com/misc/m-chart/{screenshot}.png',
 				}
 			}
 		},

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ M Chart can be installed like any other WordPress plugin.
 ## Screenshots ##
 
 ### 1. M Chart UI ###
-![M Chart UI](http://s-plugins.wordpress.org/m-chart/assets/screenshot-1.png)
+![M Chart UI](https://methnen.com/misc/m-chart/screenshot-1.png)
 
 
 ## Changelog ##


### PR DESCRIPTION
- It's obvious that wordpress.org doesn't allow hotlinking to images anymore.