### PR TITLE
Canvas context manipulation

### DIFF
--- a/components/class-m-chart-admin.php
+++ b/components/class-m-chart-admin.php
@@ -200,6 +200,11 @@ class M_Chart_Admin {
 			<input type="hidden" name="data" value="" id="<?php echo esc_attr( $this->get_field_id( 'csv-data' ) ); ?>" />
 			<input type="hidden" name="title" value="" id="<?php echo esc_attr( $this->get_field_id( 'csv-title' ) ); ?>" />
 		</form>
+		<script type="text/javascript">
+			(function( $ ) {
+				<?php do_action( 'm_chart_admin_footer_javascript' ); ?>
+			})( jQuery );
+		</script>
 		<?php
 	}
 

--- a/components/js/m-chart-admin.js
+++ b/components/js/m-chart-admin.js
@@ -233,19 +233,20 @@ var m_chart_admin = {
 
 		// Create a Canvas object out of the SVG
 		var $canvas = $( '#m-chart-canvas-render-' + event.post_id );
-		var canvas = $canvas.get( 0 );
+		m_chart_admin.canvas = $canvas.get( 0 );
 
-		canvg( canvas, svg );
+		canvg( m_chart_admin.canvas, svg );
 
-		// @TODO figure out a way to handle the canvas_context modification without the awful hack I used in the past
-		// For now we'll consider this a feature that does not exist yet
 		// Create Canvas context so we can play with it before saving
-		//var canvas_context = canvas.getContext( '2d' );
+		m_chart_admin.canvas_context = m_chart_admin.canvas.getContext( '2d' );
 
-		var img = canvas.toDataURL( 'image/png' );
+		$( '.m-chart' ).trigger({
+			type: 'canvas_done'
+		});
+
+		var img = m_chart_admin.canvas.toDataURL( 'image/png' );
 
 		// Save the image string to the text area so we can save it on update/publish
-
 		$( document.getElementById( 'm-chart-img' ) ).attr( 'value', img );
 
 		// Allow form submission now that we've got a valid img value set

--- a/components/templates/highcharts-chart.php
+++ b/components/templates/highcharts-chart.php
@@ -1,5 +1,5 @@
 <?php
-// If there's multiple instances of a chart for some reason we don't want to redeclare this
+// If there's multiple instances of a chart on the page we don't want to redeclare this
 // @TODO if the embeds end up being done via iframes this conditional won't be necessary anymore
 if ( ! $this->options_set ) {
 	?>


### PR DESCRIPTION
- Adds `canvas_done` Javascript event as well as an `m_chart_admin_footer_javascript` hook
- Also makes `canvas` and `canvas_context` vars available in the `m_chart_admin` object.

https://github.com/methnen/m-chart/issues/6