### PR TITLE
Fix custom Chart.js animation being overridden

### DIFF
--- a/components/templates/chartjs-chart.php
+++ b/components/templates/chartjs-chart.php
@@ -29,24 +29,29 @@ if ( '' != $args['width'] && 'responsive' != $args['width'] ) {
 				post_id:  this.post_id,
 				instance: this.instance
 			});
+            var target = this.chart_args.options.animation
+            var source = {
+              onComplete: function() {
+                // This deals with an issue in Chart.js 3.1.0 where onComplete can run too many times
+                // We only want to trigger on the first render anyway so we'll just check
+                if ( false === m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.render_1 ) {
+                  return;
+                }
 
-			this.chart_args.options.animation = {
-				onComplete: function() {
-					// This deals with an issue in Chart.js 3.1.0 where onComplete can run too many times
-					// We only want to trigger on the first render anyway so we'll just check
-					if ( false === m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.render_1 ) {
-						return;
-					}
+                m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.render_1 = false;
 
-					m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.render_1 = false;
-
-					$( '.m-chart' ).trigger({
-						type:     'render_done',
-						post_id:  m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.post_id,
-						instance: m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.instance
-					});
-				}
-			}
+                $( '.m-chart' ).trigger({
+                  type:     'render_done',
+                  post_id:  m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.post_id,
+                  instance: m_chart_chartjs_<?php echo absint( $post_id ); ?>_<?php echo absint( $this->instance ); ?>.instance
+                });
+              }
+            }
+            if (!target) {
+              source = {animation: source}
+              target = this.chart_args.options
+            }
+			Object.assign(target, source)
 
 			Chart.register(ChartDataLabels);
 


### PR DESCRIPTION
The current code overrides any custom animation settings for Chart.js charts defined in a theme or elsewhere. This fix merges the animation object with the onComplete property instead so that the custom animation is not removed.