### PR TITLE
1.12 code style and JS modernization

### DIFF
--- a/components/class-m-chart-admin.php
+++ b/components/class-m-chart-admin.php
@@ -64,7 +64,7 @@ class M_Chart_Admin {
 
 		$libraries = m_chart()->get_libraries();
 
-		// If there's only one library we stop here as it's unecessary
+		// If there's only one library we stop here as it's unnecessary
 		if ( 1 === count( $libraries ) ) {
 			return;
 		}
@@ -149,13 +149,13 @@ class M_Chart_Admin {
 				} else {
 					$validated_settings[ $setting ] = $default;
 				}
-			} elseif ( 'lang_settings' == $setting ) {
-				// The language settinsg require a bit more checking
+			} elseif ( 'lang_settings' === $setting ) {
+				// The language settings require a bit more checking
 				foreach ( $default_settings['lang_settings'] as $lang_setting => $lang_default ) {
-					$lang_value = $submitted_settings['lang_settings'][ $lang_setting ];
+					$lang_value = $submitted_settings[ 'lang_settings' ][ $lang_setting ];
 
-					if ( 'numericSymbols' == $lang_setting ) {
-						// The numeric symbols are input as a comma seperated string so we'll deal with that here
+					if ( 'numericSymbols' === $lang_setting ) {
+						// The numeric symbols are input as a comma separated string so we'll deal with that here
 						$numeric_symbols = explode( ',', $lang_value );
 						$safe_symbols    = array();
 
@@ -164,7 +164,7 @@ class M_Chart_Admin {
 						}
 
 						$validated_settings[ $setting ][ $lang_setting ] = $safe_symbols;
-					} elseif ( 'numericSymbolMagnitude' == $lang_setting ) {
+					} elseif ( 'numericSymbolMagnitude' === $lang_setting ) {
 						// Only want positive numbers for the numericSymbolMagnitude value
 						if ( is_numeric( $lang_value ) && 0 < $lang_value ) {
 							$validated_settings[ $setting ][ $lang_setting ] = absint( $lang_value );
@@ -258,12 +258,12 @@ class M_Chart_Admin {
 	 * @param object the current screen object as passed by the current_screen action hook
 	 */
 	public function current_screen( $screen ) {
-		if ( m_chart()->slug != $screen->post_type ) {
+		if ( m_chart()->slug !== $screen->post_type ) {
 			return;
 		}
 
 		// Only load these if we are on a post page
-		if ( 'post' == $screen->base ) {
+		if ( 'post' === $screen->base ) {
 			// jQuery Mobile Touch Events
 			wp_enqueue_script(
 				'jquery-mobile-touch-events',
@@ -326,15 +326,15 @@ class M_Chart_Admin {
 				m_chart()->version
 			);
 
-			// We need the library and post ID for some bunch of stuff below
+			// We need the library and post ID for a bunch of stuff below
 			$post_id = isset( $_GET['post'] ) ? (int) $_GET['post'] : '';
 			$library = m_chart()->get_library();
 
 			if ( ! empty( $post_id ) ) {
 				$library = m_chart()->get_post_meta( absint( $post_id ), 'library' );
 			} elseif (
-				   'post' == $screen->base
-				&& 'add' == $screen->action
+				   'post' === $screen->base
+				&& 'add' === $screen->action
 				&& isset( $_GET['library'] )
 				&& m_chart()->is_valid_library( $_GET['library'] )
 			) {
@@ -342,7 +342,7 @@ class M_Chart_Admin {
 			}
 
 			// Only load this if we are on an appropriate post page
-			if ( 'post' == $screen->base && 'chartjs' == $library ) {
+			if ( 'post' === $screen->base && 'chartjs' === $library ) {
 				wp_enqueue_script(
 					'm-chart-chartjs-admin',
 					$this->plugin_url . '/components/js/m-chart-chartjs-admin.js',
@@ -365,7 +365,7 @@ class M_Chart_Admin {
 					'image_width'             => m_chart()->get_settings( 'image_width' ),
 					'library'                 => $library,
 					'set_names'               => m_chart()->get_post_meta( $post_id, 'set_names' ),
-					'delete_comfirm'          => esc_attr__( 'Are you sure you want to delete this spreadsheet?', 'm-chart' ),
+					'delete_confirm'          => esc_attr__( 'Are you sure you want to delete this spreadsheet?', 'm-chart' ),
 				)
 			);
 
@@ -387,10 +387,10 @@ class M_Chart_Admin {
 	public function meta_boxes() {
 		global $wp_meta_boxes;
 
-		// Remove excerpt from it's normal spot in the meta_boxes array so we can put it back in after the spreadsheet
+		// Remove excerpt from its normal spot in the meta_boxes array so we can put it back in after the spreadsheet
 		// Users can move metaboxes, but this helps put things in a reasonable place on the first visit
-		$excerpt = $wp_meta_boxes[ m_chart()->slug ]['normal']['core']['postexcerpt'];
-		unset( $wp_meta_boxes[ m_chart()->slug ]['normal']['core']['postexcerpt'] );
+		$excerpt = $wp_meta_boxes[ m_chart()->slug ][ 'normal' ][ 'core' ][ 'postexcerpt' ];
+		unset( $wp_meta_boxes[ m_chart()->slug ][ 'normal' ][ 'core' ][ 'postexcerpt' ] );
 
 		add_meta_box(
 			m_chart()->slug . '-spreadsheet',
@@ -410,14 +410,14 @@ class M_Chart_Admin {
 			'high'
 		);
 
-		$wp_meta_boxes[ m_chart()->slug ]['normal']['high']['postexcerpt'] = $excerpt;
+		$wp_meta_boxes[ m_chart()->slug ][ 'normal' ][ 'high' ][ 'postexcerpt' ] = $excerpt;
 
 		// We are using our own interface for the units so we can remove the units taxonomy metabox
 		remove_meta_box( m_chart()->slug . '-unitsdiv', m_chart()->slug, 'side' );
 	}
 
 	/**
-	 * Displays the spread sheet meta box
+	 * Displays the spreadsheet meta box
 	 *
 	 * @param object the WP post object as returned by the metabox API
 	 */
@@ -453,7 +453,7 @@ class M_Chart_Admin {
 	public function admin_footer() {
 		$screen = get_current_screen();
 
-		if ( 'post' != $screen->base || m_chart()->slug != $screen->post_type ) {
+		if ( 'post' !== $screen->base || m_chart()->slug !== $screen->post_type ) {
 			return;
 		}
 		?>
@@ -481,7 +481,7 @@ class M_Chart_Admin {
 	 * @param object the WP post object as returned by the metabox API
 	 */
 	public function edit_form_before_permalink( $post ) {
-		if ( m_chart()->slug != $post->post_type ) {
+		if ( m_chart()->slug !== $post->post_type ) {
 			return;
 		}
 
@@ -498,13 +498,13 @@ class M_Chart_Admin {
 	 * @param string the $post_id of the post being displayed in this row
 	 */
 	public function manage_posts_custom_column( $column, $post_id ) {
-		if ( m_chart()->slug . '-type' != $column && m_chart()->slug . '-library' != $column ) {
+		if ( m_chart()->slug . '-type' !== $column && m_chart()->slug . '-library' !== $column ) {
 			return;
 		}
 
 		$library = m_chart()->get_post_meta( $post_id, 'library' );
 
-		if ( m_chart()->library( $library )->library != $library ) {
+		if ( m_chart()->library( $library )->library !== $library ) {
 			?>
 <span aria-hidden="true">—</span>
 <span class="screen-reader-text"><?php echo esc_html__( 'Library not found', 'm-chart' ); ?></span>
@@ -512,7 +512,7 @@ class M_Chart_Admin {
 			return;
 		}
 
-		if ( m_chart()->slug . '-type' == $column ) {
+		if ( m_chart()->slug . '-type' === $column ) {
 			$type      = m_chart()->get_post_meta( $post_id, 'type' );
 			$type_name = m_chart()->library( $library )->type_option_names[ $type ];
 			?>
@@ -522,7 +522,7 @@ class M_Chart_Admin {
 			<?php
 		}
 
-		if ( m_chart()->slug . '-library' == $column ) {
+		if ( m_chart()->slug . '-library' === $column ) {
 			$library_name = m_chart()->library( $library )->library_name;
 			?>
 <span class="library <?php echo esc_attr( $library ); ?>" title="<?php echo esc_attr( $library_name ); ?>">
@@ -553,10 +553,10 @@ class M_Chart_Admin {
 		foreach ( $columns as $column => $name ) {
 			$new_columns[ $column ] = $name;
 
-			if ( 'author' == $column || 'coauthors' == $column ) {
+			if ( 'author' === $column || 'coauthors' === $column ) {
 				$new_columns[ m_chart()->slug . '-type' ] = 'Type';
 
-				if ( 'yes' == m_chart()->get_settings( 'show_library' ) ) {
+				if ( 'yes' === m_chart()->get_settings( 'show_library' ) ) {
 					$new_columns[ m_chart()->slug . '-library' ] = 'Library';
 				}
 			}
@@ -579,7 +579,7 @@ class M_Chart_Admin {
 		}
 
 		// Check post type
-		if ( ! isset( $post->post_type ) || m_chart()->slug != $post->post_type ) {
+		if ( ! isset( $post->post_type ) || m_chart()->slug !== $post->post_type ) {
 			return;
 		}
 
@@ -633,19 +633,19 @@ class M_Chart_Admin {
 		$settings = m_chart()->get_settings();
 
 		// If the performance setting isn't turned to default we don't do this
-		if ( 'default' != $settings['performance'] ) {
-			return;
+		if ( 'default' !== $settings['performance'] ) {
+			return false;
 		}
 
 		if ( ! is_numeric( $_POST['post_ID'] ) ) {
-			return;
+			return false;
 		}
 
 		$post_id = absint( $_POST['post_ID'] );
 
 		// Make sure the library used on this post supports images
-		if ( 'no' == apply_filters( 'm_chart_image_support', 'no', m_chart()->get_post_meta( $post_id, 'library' ) ) ) {
-			return;
+		if ( 'no' === apply_filters( 'm_chart_image_support', 'no', m_chart()->get_post_meta( $post_id, 'library' ) ) ) {
+			return false;
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
@@ -656,14 +656,14 @@ class M_Chart_Admin {
 			return false;
 		}
 
-		if ( '' == $_POST[ m_chart()->slug ]['img'] ) {
+		if ( '' === $_POST[ m_chart()->slug ]['img'] ) {
 			return false;
 		}
 
 		// Decode the image so we can save it
 		$decoded_img = base64_decode( str_replace( 'data:image/png;base64,', '', $_POST[ m_chart()->slug ]['img'] ) );
 
-		if ( '' == $decoded_img ) {
+		if ( '' === $decoded_img ) {
 			return false;
 		}
 
@@ -714,13 +714,13 @@ class M_Chart_Admin {
 	/**
 	 * Parses an incoming CSV file and compiles it into an array
 	 *
-	 * @return array an array fo the data from the imported CSV file ready for use in the chart meta
+	 * @return array an array of the data from the imported CSV file ready for use in the chart meta
 	 */
 	public function ajax_import_csv() {
 		$post = get_post( absint( $_POST['post_id'] ) );
 
 		// Check post type
-		if ( ! isset( $post->post_type ) || m_chart()->slug != $post->post_type ) {
+		if ( ! isset( $post->post_type ) || m_chart()->slug !== $post->post_type ) {
 			wp_send_json_error( esc_html__( 'Wrong post type', 'm-chart' ) );
 		}
 
@@ -742,8 +742,8 @@ class M_Chart_Admin {
 		// Make sure the file is a CSV file
 		$file_ext = strtolower( pathinfo( $_FILES['import_csv_file']['name'], PATHINFO_EXTENSION ) );
 
-		if ( 'csv' != $file_ext ) {
-			wp_send_json_error( esc_html__( 'Only CSV files can be imported ', 'm-chart' ) );
+		if ( 'csv' !== $file_ext ) {
+			wp_send_json_error( esc_html__( 'Only CSV files can be imported', 'm-chart' ) );
 		}
 
 		// Do some validation on the CSV file (mirroring what WP does for this sort of thing)
@@ -755,7 +755,7 @@ class M_Chart_Admin {
 
 		$csv_data = file_get_contents( $csv_file );
 
-		if ( '' == $csv_data ) {
+		if ( '' === $csv_data ) {
 			wp_send_json_error( esc_html__( 'CSV file was empty', 'm-chart' ) );
 		}
 
@@ -769,10 +769,10 @@ class M_Chart_Admin {
 		// Which then seems to confuse parseCSV occasionally
 		$csv_data = "\n" . trim( $csv_data ) . "\n";
 
-		// Set delimiter
-		$parse_csv->delimiter = isset( $_POST['csv_delimiter'] ) ? $_POST['csv_delimiter'] : m_chart()->get_settings( 'csv_delimiter' );
-		
-		// Parse the CSV 
+		// Set delimiter but check to make sure it's safe first
+		$parse_csv->delimiter = isset( $_POST['csv_delimiter'] ) && in_array( $_POST['csv_delimiter'], $this->safe_settings[ 'csv_delimiter' ] ) ? $_POST['csv_delimiter'] : m_chart()->get_settings( 'csv_delimiter' );
+
+		// Parse the CSV
 		$parse_csv->parse( $csv_data );
 
 		// This deals with Google Doc's crappy CSV exports which don't include columns at the end of a row if they are empty
@@ -787,7 +787,7 @@ class M_Chart_Admin {
 	 *
 	 * @param array an array of data as returned from the parseCSV class
 	 *
-	 * @param array the array of data with matching array value counts
+	 * @return array the array of data with matching array value counts
 	 */
 	public function fix_csv_data_array( $data_array ) {
 		$count = 0;
@@ -821,6 +821,8 @@ class M_Chart_Admin {
 	public function ajax_export_csv() {
 		// Purposely using $_REQUEST here since this method can work via a GET and POST request
 		// POST requests are used when passing the data value since it's too big to pass via GET
+		// There is no nonce check here because a traditional WP nonce check would not work
+		// Instead we confirm the user has necessary permissions for the post in question
 		if ( ! is_numeric( $_REQUEST['post_id'] ) || ! current_user_can( 'edit_post', absint( $_REQUEST['post_id'] ) ) ) {
 			wp_die( 'Unauthorized access', 'You do not have permission to do that', array( 'response' => 401 ) );
 		}
@@ -878,7 +880,9 @@ class M_Chart_Admin {
 			wp_send_json_error( esc_html__( 'Invalid library', 'm-chart' ) );
 		}
 
-		if ( 'highcharts' == $_POST['library'] ) {
+		// This does get potentially overwritten later on
+		// However, it's necessary for initial load on a new chart
+		if ( 'highcharts' === $_POST['library'] ) {
 			$library = m_chart()->library( $_POST['library'] );
 		}
 
@@ -903,7 +907,7 @@ class M_Chart_Admin {
 	 * @param string a name spaced field name
 	 */
 	public function get_field_name( $field_name, $parent_field_name = '' ) {
-		if ( '' != $parent_field_name ) {
+		if ( '' !== $parent_field_name ) {
 			return m_chart()->slug . '[' . $parent_field_name . ']' . '[' . $field_name . ']';
 		}
 

--- a/components/js/m-chart-admin.js
+++ b/components/js/m-chart-admin.js
@@ -83,7 +83,7 @@
 
 	// Instantiate the spreadsheets
 	m_chart_admin.build_spreadsheets = function() {
-		this.$spreadsheet_divs   = $( document.getElementById( 'spreadsheets' ) );
+		this.$spreadsheet_divs  = $( document.getElementById( 'spreadsheets' ) );
 		this.$spreadsheet_tabs  = $( document.getElementById( 'spreadsheet-tabs' ) );
 		this.sheet_div_template = Handlebars.compile( $( document.getElementById( 'm-chart-sheet-div' ) ).html() );
 		this.sheet_tab_template = Handlebars.compile( $( document.getElementById( 'm-chart-sheet-tab' ) ).html() );

--- a/components/js/m-chart-admin.js
+++ b/components/js/m-chart-admin.js
@@ -83,7 +83,7 @@
 
 	// Instantiate the spreadsheets
 	m_chart_admin.build_spreadsheets = function() {
-		this.spreadsheet_divs   = $( document.getElementById( 'spreadsheets' ) );
+		this.$spreadsheet_divs   = $( document.getElementById( 'spreadsheets' ) );
 		this.$spreadsheet_tabs  = $( document.getElementById( 'spreadsheet-tabs' ) );
 		this.sheet_div_template = Handlebars.compile( $( document.getElementById( 'm-chart-sheet-div' ) ).html() );
 		this.sheet_tab_template = Handlebars.compile( $( document.getElementById( 'm-chart-sheet-tab' ) ).html() );
@@ -100,7 +100,7 @@
 
 	// Instantiate a spreadsheet
 	m_chart_admin.create_spreadsheet = function( i, data ) {
-		this.spreadsheet_divs.append( this.sheet_div_template( { post_id: this.post_id, instance: i } ) );
+		this.$spreadsheet_divs.append( this.sheet_div_template( { post_id: this.post_id, instance: i } ) );
 		// Note we're purposely not getting a jQuery version of this object because Jspreadsheet likes it that way
 		const spreadsheet_div = document.getElementById( `spreadsheet-${this.post_id}-${i}` );
 
@@ -244,7 +244,7 @@
 				return;
 			}
 
-			m_chart_admin.spreadsheet_divs.find( '.spreadsheet' ).addClass( 'hide' );
+			m_chart_admin.$spreadsheet_divs.find( '.spreadsheet' ).addClass( 'hide' );
 			$( document.getElementById( `spreadsheet-${m_chart_admin.post_id}-${$( this ).data( 'instance' )}` ) ).removeClass( 'hide' );
 
 			m_chart_admin.$spreadsheet_tabs.find( '.nav-tab' ).removeClass( 'nav-tab-active' );

--- a/components/js/m-chart-admin.js
+++ b/components/js/m-chart-admin.js
@@ -17,12 +17,12 @@
 
 		// Build the spreadsheets
 		this.build_spreadsheets();
-		
+
 		// Handle the spreadsheet controls
 		this.handle_sheet_controls();
 
 		// Set the form encoding type to multipart/form-data so that the CSV import will work
-		let $form = $( 'form#post' );
+		const $form = $( 'form#post' );
 		$form.attr( 'enctype', 'multipart/form-data' );
 
 		// Watch form submissions and stop them if necessary or update data value
@@ -69,56 +69,56 @@
 
 	// Get data from the spreadsheets
 	m_chart_admin.get_data = function() {
-		let $data = [];
+		const data = [];
 
 		let spreadsheet = 0;
 
 		$.each( this.$spreadsheets, function( i ) {
-			$data[ spreadsheet ] = m_chart_admin.$spreadsheets[ i ].getData();
+			data[ spreadsheet ] = m_chart_admin.$spreadsheets[ i ].getData();
 			spreadsheet++;
 		});
 
-		return $data;
-	}
+		return data;
+	};
 
 	// Instantiate the spreadsheets
 	m_chart_admin.build_spreadsheets = function() {
-		this.$spreadsheet_divs  = $( document.getElementById( 'spreadsheets' ) );
+		this.spreadsheet_divs   = $( document.getElementById( 'spreadsheets' ) );
 		this.$spreadsheet_tabs  = $( document.getElementById( 'spreadsheet-tabs' ) );
 		this.sheet_div_template = Handlebars.compile( $( document.getElementById( 'm-chart-sheet-div' ) ).html() );
 		this.sheet_tab_template = Handlebars.compile( $( document.getElementById( 'm-chart-sheet-tab' ) ).html() );
 
 		this.$spreadsheets = {};
 
-		// hands_on_table_data is an array of data sets so we cycle through them and build a spreadsheet object for each one
-		$.each( hands_on_table_data, function( i, data ) {
-			let instance = Number( i ) + 1;
+		// spreadsheet_data is an array of data sets so we cycle through them and build a spreadsheet object for each one
+		$.each( spreadsheet_data, function( i, data ) {
+			const instance = Number( i ) + 1;
 
 			m_chart_admin.create_spreadsheet( instance, data );
 		});
-	}
+	};
 
-	// Instantiate a spreedsheet
+	// Instantiate a spreadsheet
 	m_chart_admin.create_spreadsheet = function( i, data ) {
-		this.$spreadsheet_divs.append( this.sheet_div_template( { post_id: this.post_id, instance: i } ) );
+		this.spreadsheet_divs.append( this.sheet_div_template( { post_id: this.post_id, instance: i } ) );
 		// Note we're purposely not getting a jQuery version of this object because Jspreadsheet likes it that way
-		let $spreadsheet_div = document.getElementById( 'spreadsheet-' + this.post_id + '-' + i );
+		const spreadsheet_div = document.getElementById( `spreadsheet-${this.post_id}-${i}` );
 
 		// New charts won't actually have data so we'll pass something Jspreadsheet understands
-		if ( '' == data ) {
+		if ( '' === data ) {
 			data = [[]];
 		}
 
-		let $context_menu_items = [
+		const context_menu_items = [
 			'Insert a new row before',
 			'Insert a new row after',
 			'Delete selected rows',
 			'Insert a new column before',
 			'Insert a new column after',
 			'Delete selected columns',
-		]
+		];
 
-		let spreadsheet = jspreadsheet( $spreadsheet_div, {
+		const spreadsheet = jspreadsheet( spreadsheet_div, {
 			worksheets: [{
 				data: data,
 				allowComments: false,
@@ -126,17 +126,17 @@
 			}],
 			contextMenu: function(obj, x, y, e, items, section) {
 				// Iterate through contextual menu items and only include the ones we want
-				let filtered_items = items.filter(item => {
-					if ($context_menu_items.includes( item.title )) {
-						return item.title
+				const filtered_items = items.filter(item => {
+					if ( context_menu_items.includes( item.title ) ) {
+						return true;
 					}
 				});
-				
+
 				return filtered_items;
 			},
 			onload: function(spreadsheet) {
 				// Run an auto width function to make the column widths match content
-				let worksheet = spreadsheet.worksheets[spreadsheet.getWorksheetActive()];
+				const worksheet = spreadsheet.worksheets[spreadsheet.getWorksheetActive()];
 				m_chart_admin.spreadsheet_auto_width(worksheet);
 			},
 			onafterchanges: function(worksheet, records) {
@@ -150,30 +150,30 @@
 
 		this.$spreadsheets[i] = spreadsheet[0];
 
-		// Built tab for sheet this sheet (it's only visible if the user selects an appropriate chart type but we build it now anyway)
-		let $template_vars = {
+		// Build a tab for this sheet (it's only visible if the user selects an appropriate chart type but we build it now anyway)
+		const template_vars = {
 			post_id: m_chart_admin.post_id,
 			instance: i
 		};
 
 		if ( i > 0 ) {
-			$( $spreadsheet_div ).addClass( 'hide' );
-			$template_vars.class = 'nav-tab';
+			$( spreadsheet_div ).addClass( 'hide' );
+			template_vars.class = 'nav-tab';
 		} else {
 			this.active_set = i;
-			$template_vars.class = 'nav-tab nav-tab-active';
+			template_vars.class = 'nav-tab nav-tab-active';
 		}
 
 		if ( 'undefined' !== typeof this.set_names[ i - 1 ] ) {
-			$template_vars.value = this.set_names[ i - 1 ];
+			template_vars.value = this.set_names[ i - 1 ];
 		} else {
-			$template_vars.value = 'Sheet ' + i;
+			template_vars.value = `Sheet ${i}`;
 		}
 
-		this.$spreadsheet_tabs.append( this.sheet_tab_template( $template_vars ) );
+		this.$spreadsheet_tabs.append( this.sheet_tab_template( template_vars ) );
 
 		// Set the tab input width
-		let $tab_input = $( '#spreadsheet-tab-' + this.post_id + '-' + i + ' input' );
+		const $tab_input = $( `#spreadsheet-tab-${this.post_id}-${i} input` );
 		m_chart_admin.resize_input( $tab_input );
 
 		this.last_set = i;
@@ -197,8 +197,8 @@
 		// Auto-resize the width of the columns that need it
 		columns.forEach(column => {
 			let max_width = 0;
-			let min_width = 100; // This matches the default width for a column
-			const padding = 13; // Some additional padding to keep things attractive
+			const min_width = 100; // This matches the default width for a column
+			const padding   = 13; // Some additional padding to keep things attractive
 
 			// Check each cell in the column for the widest content
 			for ( let i = 0; i < worksheet.records.length; i++ ) {
@@ -206,7 +206,7 @@
 					const cell    = worksheet.records[i][column].element;
 					context.font  = window.getComputedStyle( cell ).font;
 					const metrics = context.measureText( cell.innerText );
-					
+
 					if ( metrics.width > max_width ) {
 						max_width = metrics.width;
 					}
@@ -223,11 +223,11 @@
 
 	// Handle spreadsheet functionality
 	m_chart_admin.handle_sheet_controls = function() {
-		// Add a spreedsheet
+		// Add a spreadsheet
 		this.$spreadsheet_tabs.find( '.add-sheet' ).on( 'click', function( event ) {
 			event.preventDefault();
 			m_chart_admin.create_spreadsheet( m_chart_admin.last_set + 1, '' );
-			let new_tab = document.getElementById( 'spreadsheet-tab-' + m_chart_admin.post_id + '-' + m_chart_admin.last_set );
+			const new_tab = document.getElementById( `spreadsheet-tab-${m_chart_admin.post_id}-${m_chart_admin.last_set}` );
 
 			// Check tab count
 			m_chart_admin.check_tab_count();
@@ -244,15 +244,14 @@
 				return;
 			}
 
-			m_chart_admin.$spreadsheet_divs.find( '.spreadsheet' ).addClass( 'hide' );
-			$( document.getElementById( 'spreadsheet-' + m_chart_admin.post_id + '-' + $(this).data( 'instance' ) ) ).removeClass( 'hide' );
+			m_chart_admin.spreadsheet_divs.find( '.spreadsheet' ).addClass( 'hide' );
+			$( document.getElementById( `spreadsheet-${m_chart_admin.post_id}-${$( this ).data( 'instance' )}` ) ).removeClass( 'hide' );
 
 			m_chart_admin.$spreadsheet_tabs.find( '.nav-tab' ).removeClass( 'nav-tab-active' );
 			$( this ).addClass( 'nav-tab-active' );
-			m_chart_admin.active_set = $(this).data( 'instance' );
+			m_chart_admin.active_set = $( this ).data( 'instance' );
 		});
 
-		
 		// Handle double clicks and long presses on the tabs
 		this.$spreadsheet_tabs.on( 'dblclick taphold', '.nav-tab', function( event ) {
 			event.preventDefault();
@@ -269,7 +268,7 @@
 
 		// Set input back to disabled on return/enter
 		this.$spreadsheet_tabs.on( 'keydown', 'input', function( event ) {
-			if ( 13 === event.keyCode ) {
+			if ( 'Enter' === event.key ) {
 				event.preventDefault();
 
 				m_chart_admin.handle_tab_blur( this );
@@ -277,34 +276,34 @@
 			}
 		});
 
-		// Resize the input based on it's value
+		// Resize the input based on its value
 		this.$spreadsheet_tabs.on( 'keydown keyup input propertychange change', 'input', function( event ) {
 			m_chart_admin.resize_input( $( this ) );
 		});
 
 		// Remove a tab/spreadsheet
 		this.$spreadsheet_tabs.on( 'click', '.dashicons-dismiss', function( event ) {
-			if ( ! confirm( m_chart_admin.delete_comfirm ) ) {
+			if ( ! confirm( m_chart_admin.delete_confirm ) ) {
 				return;
 			}
 
-			let $tab = $( this ).closest( '.nav-tab' );
+			const $tab = $( this ).closest( '.nav-tab' );
 
 			// Select the tab we're working with if necessary
 			if ( ! $tab.hasClass( 'nav-tab-active' ) ) {
 				$tab.click();
 			}
 
-			let instance = $( this ).closest( '.nav-tab' ).data( 'instance' );
+			const instance = $( this ).closest( '.nav-tab' ).data( 'instance' );
 
-			// Delete the spreedsheet
+			// Delete the spreadsheet
 			delete m_chart_admin.$spreadsheets[ instance ];
 
 			// Remove the tab
 			$tab.remove();
 
-			// Remove the spreedsheet div
-			$( document.getElementById( 'spreadsheet-' + m_chart_admin.post_id + '-' + instance ) ).remove();
+			// Remove the spreadsheet div
+			$( document.getElementById( `spreadsheet-${m_chart_admin.post_id}-${instance}` ) ).remove();
 
 			// Check tab count
 			m_chart_admin.check_tab_count();
@@ -322,55 +321,55 @@
 	m_chart_admin.handle_tab_blur = function( tab ) {
 		$( tab ).addClass( 'hide' );
 
-		let $tab_title = $( tab ).closest('.nav-tab').find('.tab-title');
+		const $tab_title = $( tab ).closest( '.nav-tab' ).find( '.tab-title' );
 		$tab_title.text( $( tab ).val() );
 		$tab_title.removeClass( 'hide' );
 	};
 
 	// Set last tab as do-not-delete if tab count is 1
 	m_chart_admin.check_tab_count = function() {
-		if ( 1 == this.$spreadsheet_tabs.find( '.nav-tab' ).length ) {
+		if ( 1 === this.$spreadsheet_tabs.find( '.nav-tab' ).length ) {
 			this.$spreadsheet_tabs.find( '.nav-tab' ).addClass( 'do-not-delete' );
 		} else {
 			this.$spreadsheet_tabs.find( '.nav-tab' ).removeClass( 'do-not-delete' );
 		}
 	};
 
-	// Resize an input based on it's value
+	// Resize an input based on its value
 	m_chart_admin.resize_input = function( $input ) {
 		// Get what we need to calculate the value width
-		let font = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).font;
-		let text = $input.val();
+		const font = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).font;
+		const text = $input.val();
 
 		// Get what we need to properly size the input with the value width
-		let border_width  = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).getPropertyValue( 'border-width' ).replace( 'px', '' );
-		let padding_left  = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).getPropertyValue( 'padding-left' ).replace( 'px', '' );
-		let padding_right = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).getPropertyValue( 'padding-right' ).replace( 'px', '' );
+		const border_width  = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).getPropertyValue( 'border-width' ).replace( 'px', '' );
+		const padding_left  = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).getPropertyValue( 'padding-left' ).replace( 'px', '' );
+		const padding_right = window.getComputedStyle( document.getElementById( $input.attr( 'id' ) ) ).getPropertyValue( 'padding-right' ).replace( 'px', '' );
 
 		// Calculate width of the input value
-		let input_canvas  = document.createElement( 'canvas' );
-	    let input_context = input_canvas.getContext( '2d' );
+		const input_canvas  = document.createElement( 'canvas' );
+		const input_context = input_canvas.getContext( '2d' );
 
 		input_context.font = font;
 
-		let metrics = input_context.measureText( text );
-		let width   = Math.ceil( metrics.width ) + 1;
+		const metrics = input_context.measureText( text );
+		const width   = Math.ceil( metrics.width ) + 1;
 
-		$input.css( 'width', ( border_width * 2 ) + parseInt( padding_left ) + width + parseInt( padding_right ) + 'px' );
+		$input.css( 'width', `${( border_width * 2 ) + parseInt( padding_left, 10 ) + width + parseInt( padding_right, 10 )}px` );
 	};
 
 	// Handle CSV import functionality
 	m_chart_admin.handle_csv_import = function() {
-		let $csv_container = $( document.getElementById( 'm-chart-csv' ) );
-		let $select        = $csv_container.find( '.import .select.button' );
-		let $confirmation  = $csv_container.find( '.import .confirmation' );
-		let $import_form   = $( document.getElementById( 'm-chart-csv-import-form' ) );
-		let $file_input    = $import_form.find( 'input[type=file]' );
-		let $file_info     = $csv_container.find( '.file-info' );
-		let $file_error    = $csv_container.find( '.file.error' );
-		let $file_import   = $csv_container.find( '.import.in-progress' );
-		let $import_error  = $csv_container.find( '.import.error' );
-		let $cancel        = $csv_container.find( '.dashicons-dismiss' );
+		const $csv_container = $( document.getElementById( 'm-chart-csv' ) );
+		const $select        = $csv_container.find( '.import .select.button' );
+		const $confirmation  = $csv_container.find( '.import .confirmation' );
+		const $import_form   = $( document.getElementById( 'm-chart-csv-import-form' ) );
+		const $file_input    = $import_form.find( 'input[type=file]' );
+		const $file_info     = $csv_container.find( '.file-info' );
+		const $file_error    = $csv_container.find( '.file.error' );
+		const $file_import   = $csv_container.find( '.import.in-progress' );
+		const $import_error  = $csv_container.find( '.import.error' );
+		const $cancel        = $csv_container.find( '.dashicons-dismiss' );
 
 		// Watch for clicks on the select button
 		$select.on( 'click', function( event ) {
@@ -382,7 +381,7 @@
 
 		// Watch for changes to the file input
 		$file_input.on( 'change', function( event ) {
-			let file_name = $( this ).val().replace( /C:\\fakepath\\/i, '' );
+			const file_name = $( this ).val().replace( /C:\\fakepath\\/i, '' );
 
 			if ( -1 === file_name.search( /.+(\.csv)$/ ) ) {
 				$file_error.removeClass( 'hide' );
@@ -421,16 +420,16 @@
 		$import_form.on( 'submit', function( event ) {
 			event.preventDefault();
 
-			let $form_data = new FormData( this );
+			const form_data = new FormData( this );
 
-			$form_data.append( 'post_id', m_chart_admin.post_id );
-			$form_data.append( 'csv_delimiter', $confirmation.find( 'select' ).val() );
-			$form_data.append( 'nonce', m_chart_admin.nonce );
+			form_data.append( 'post_id', m_chart_admin.post_id );
+			form_data.append( 'csv_delimiter', $confirmation.find( 'select' ).val() );
+			form_data.append( 'nonce', m_chart_admin.nonce );
 
-			let request = $.ajax({
+			const request = $.ajax({
 				url: 'admin-ajax.php?action=m_chart_import_csv',
 				type: 'POST',
-				data: $form_data,
+				data: form_data,
 				cache: false,
 				dataType: 'json',
 				// Don't process the files
@@ -439,8 +438,8 @@
 				contentType: false
 			});
 
-			request.done( function( response ) {
-				if ( false == response.success ) {
+			request.done( ( response ) => {
+				if ( false === response.success ) {
 					$import_error.text( response.data );
 					$import_error.removeClass( 'hide' );
 
@@ -466,13 +465,12 @@
 		$( document.getElementById( 'm-chart-csv' ) ).find( '.export a' ).on( 'click', function( event ) {
 			event.preventDefault();
 
-			let $form = $( document.getElementById( 'm-chart-csv-export-form' ) );
-			let $data = m_chart_admin.$spreadsheets[ m_chart_admin.active_set ].getData();
-
-			let set_name = m_chart_admin.$spreadsheet_tabs.find( '.nav-tab-active input' ).val();
+			const $form    = $( document.getElementById( 'm-chart-csv-export-form' ) );
+			const data     = m_chart_admin.$spreadsheets[ m_chart_admin.active_set ].getData();
+			const set_name = m_chart_admin.$spreadsheet_tabs.find( '.nav-tab-active input' ).val();
 
 			$( document.getElementById( 'm-chart-csv-post-id' ) ).val( m_chart_admin.post_id );
-			$( document.getElementById( 'm-chart-csv-data' ) ).val( JSON.stringify( $data ) );
+			$( document.getElementById( 'm-chart-csv-data' ) ).val( JSON.stringify( data ) );
 			$( document.getElementById( 'm-chart-csv-title' ) ).val( m_chart_admin.$title_input.val() );
 			$( document.getElementById( 'm-chart-csv-set-name' ) ).val( set_name );
 
@@ -482,15 +480,15 @@
 
 	// Watch for changes to the chart settings or title
 	m_chart_admin.watch_for_chart_changes = function() {
-		this.$setting_inputs.on( 'change', function() {
+		this.$setting_inputs.on( 'change', () => {
 			m_chart_admin.refresh_chart();
 		});
 
-		this.$title_input.on( 'change', function() {
+		this.$title_input.on( 'change', () => {
 			m_chart_admin.refresh_chart();
 		});
 
-		this.$subtitle_input.on( 'change', function() {
+		this.$subtitle_input.on( 'change', () => {
 			m_chart_admin.refresh_chart();
 		});
 	};
@@ -509,8 +507,8 @@
 		// Stop form submission while we wait for the chart to refresh and a new image to generate
 		m_chart_admin.form_submission( false );
 
-		// Build an object with all fo the post_meta values
-		let $post_meta = {};
+		// Build an object with all of the post_meta values
+		const post_meta = {};
 
 		$.each( this.$setting_inputs, function() {
 			// Don't record unselected/unchecked radio/checkboxes
@@ -519,18 +517,18 @@
 				&& 'checkbox' !== $( this ).attr( 'type' )
 				|| true === $( this ).is( ':checked' )
 			 ) {
-				$post_meta[ $( this ).attr( 'name' ).replace( /^m-chart\[|\]$/g , '' ) ] = $( this ).val();
+				post_meta[ $( this ).attr( 'name' ).replace( /^m-chart\[|\]$/g , '' ) ] = $( this ).val();
 			}
 		});
 
-		$post_meta[ 'subtitle' ] = this.$subtitle_input.val();
+		post_meta.subtitle = this.$subtitle_input.val();
 
-		$post_meta.data = JSON.stringify( m_chart_admin.get_data() );
+		post_meta.data = JSON.stringify( m_chart_admin.get_data() );
 
-		$post_meta['set_names'] = [];
+		post_meta.set_names = [];
 
 		$.each( this.$spreadsheet_tabs.find( '.nav-tab' ), function( i ) {
-			$post_meta['set_names'][ i ] = $( this ).find( 'input' ).val();
+			post_meta.set_names[ i ] = $( this ).find( 'input' ).val();
 		});
 
 		// Request a new chart_args object so we can rerender the chart with the changes
@@ -542,13 +540,13 @@
 				nonce:     m_chart_admin.nonce,
 				library:   m_chart_admin.library,
 				title:     this.$title_input.val(),
-				post_meta: $post_meta
+				post_meta: post_meta
 			},
 			cache: false,
 			dataType: 'json'
 		});
 
-		this.request.done( function( response ) {
+		this.request.done( ( response ) => {
 			if ( true !== response.success ) {
 				return false;
 			}
@@ -570,7 +568,7 @@
 		}
 	};
 
-	$( function() {
+	$( () => {
 		m_chart_admin.init();
 	} );
 })( jQuery );

--- a/components/js/m-chart-admin.js
+++ b/components/js/m-chart-admin.js
@@ -135,12 +135,12 @@
 				return filtered_items;
 			},
 			onload: function(spreadsheet) {
-				// Run an auto width function to make the column widths
+				// Run an auto width function to make the column widths match content
 				let worksheet = spreadsheet.worksheets[spreadsheet.getWorksheetActive()];
 				m_chart_admin.spreadsheet_auto_width(worksheet);
 			},
 			onafterchanges: function(worksheet, records) {
-				// Run an auto width function to make the column widths
+				// Run an auto width function to make the column widths match content
 				m_chart_admin.spreadsheet_auto_width(worksheet, records);
 
 				// Update chart on spreadsheet changes

--- a/components/templates/spreadsheet-meta-box.php
+++ b/components/templates/spreadsheet-meta-box.php
@@ -1,5 +1,5 @@
 <script type="text/javascript" charset="utf-8">
-	var hands_on_table_data = <?php echo json_encode( $sheet_data ); ?>;
+	var spreadsheet_data = <?php echo json_encode( $sheet_data ); ?>;
 </script>
 <nav id="spreadsheet-tabs" class="nav-tab-wrapper hide">
 	<a href="#add-sheet" class="add-sheet" title="<?php esc_html_e( 'Add Sheet', 'm-chart' ); ?>"><span class="dashicons dashicons-plus-alt"></span></a>


### PR DESCRIPTION
## Summary

- **PHP**: Fix typos in comments/docblocks, fix `@param` → `@return` in `fix_csv_data_array`, remove trailing space in error string, add missing spaces in array key access per WP coding standards
- **JS**: Rename legacy `hands_on_table_data` → `spreadsheet_data`, replace `$` prefix on non-jQuery variables, `let` → `const` throughout, string concatenation → template literals, deprecated `event.keyCode` → `event.key`, add `parseInt` radix, bracket → dot notation for known keys, callbacks without `this` → arrow functions
- **Template**: Rename `hands_on_table_data` → `spreadsheet_data` to match JS