### PR TITLE
2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** chartjs, graphs, charts, tables, data  
 **Requires PHP:** 8.1  
 **Tested up to:** 7.0  
-**Stable tag:** 2.2.1  
+**Stable tag:** 2.2.2  
 **License:** MIT  
 
 Manage data sets via a spreadsheet interface, display them as charts via the Chart.js chart library, and embed them via a shortcode or block.
@@ -63,8 +63,7 @@ To contribute, report issues, or make feature requests use [Github](https://gith
 ### 2.2.2 ###
 
 * Added a new m_chart_admin_initial_chart_args filter so extensions can modify or replace the chart args used for the editor's initial preview render
-* Fixed an issue where titles, subtitles, and axis titles containing an apostrophe or quote could show a stray backslash on the chart
-	* Removed some legacy slash-escaping left over from the pre-2.0 rendering stack and tightened up the JSON encoding of chart args along the way
+* Removed some legacy slash-escaping left over from the pre-2.0 rendering stack and tightened up the JSON encoding of chart args along the way
 
 ### 2.2.1 ###
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ M Chart Pro will be where I add those out of scope features as an addon to M Cha
 
 For full documentation please see the [Documentation](https://docs.mch.art/).
 
-To contribute, report issues, or make feature requests use [Github](https://github.com/methnen/m-chart). 
+To contribute, report issues, or make feature requests use [Github](https://github.com/methnen/m-chart).
 
 ## Screenshots ##
 
@@ -59,6 +59,12 @@ To contribute, report issues, or make feature requests use [Github](https://gith
 
 
 ## Changelog ##
+
+### 2.2.2 ###
+
+* Added a new m_chart_admin_initial_chart_args filter so extensions can modify or replace the chart args used for the editor's initial preview render
+* Fixed an issue where titles, subtitles, and axis titles containing an apostrophe or quote could show a stray backslash on the chart
+	* Removed some legacy slash-escaping left over from the pre-2.0 rendering stack and tightened up the JSON encoding of chart args along the way
 
 ### 2.2.1 ###
 

--- a/components/class-m-chart-admin.php
+++ b/components/class-m-chart-admin.php
@@ -640,6 +640,9 @@ class M_Chart_Admin {
 				);
 			}
 
+			// Allow extensions to modify or replace the chart args used for the editor's initial preview render
+			$initial_chart_args = apply_filters( 'm_chart_admin_initial_chart_args', $initial_chart_args, $post_id, $library );
+
 			// Build CSV delimiter map for React's CsvControls component
 			$csv_delimiters = [];
 			foreach ( m_chart()->csv_delimiters as $delimiter => $delimiter_name ) {

--- a/components/class-m-chart-chartjs.php
+++ b/components/class-m-chart-chartjs.php
@@ -1142,7 +1142,7 @@ class M_Chart_Chartjs {
 							$new_data_array[] = [
 								'x'     => $x,
 								'y'     => $data_array[1][ $i ],
-								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $i ],
+								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $i ] ?? '',
 							];
 						}
 					} else {
@@ -1151,7 +1151,7 @@ class M_Chart_Chartjs {
 							$new_data_array[] = [
 								'x'     => $data[0],
 								'y'     => $data[1],
-								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $data_key ],
+								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $data_key ] ?? '',
 							];
 						}
 					}
@@ -1196,7 +1196,7 @@ class M_Chart_Chartjs {
 								'x'     => $x,
 								'y'     => $data_array[1][ $i ],
 								'r'     => $data_array[2][ $i ],
-								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $i ],
+								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $i ] ?? '',
 							];
 						}
 					} else {
@@ -1206,7 +1206,7 @@ class M_Chart_Chartjs {
 								'x'     => $data[0],
 								'y'     => $data[1],
 								'r'     => $data[2],
-								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $data_key ],
+								'label' => $parse->value_labels[ M_Chart_Parse::LABELS_FIRST_COLUMN ][ $data_key ] ?? '',
 							];
 						}
 					}
@@ -1241,7 +1241,7 @@ class M_Chart_Chartjs {
 
 			foreach ( $data_array as $key => $data_chunk ) {
 				$set_data[ $key ] = [
-					'label'   => m_chart()->parse()->value_labels[ $label_key ][ $key ],
+					'label'   => m_chart()->parse()->value_labels[ $label_key ][ $key ] ?? '',
 					'data'    => [],
 					'rawData' => isset( $raw_data[ $key ] ) ? $raw_data[ $key ] : [],
 				];
@@ -1331,8 +1331,7 @@ class M_Chart_Chartjs {
 		$string = wp_strip_all_tags( $string );
 		$string = str_replace( '{{m-chart-br}}', '<br />', $string );
 
-		// @TODO: See if this addslashes/stripslashes is still necessary (need to remember why I did it first...)
-		return addslashes( stripslashes( $string ) );
+		return $string;
 	}
 
 	/**

--- a/components/class-m-chart.php
+++ b/components/class-m-chart.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class M_Chart {
-	public $version           = '2.2.1';
+	public $version           = '2.2.2';
 	public $slug              = 'm-chart';
 	public $plugin_name       = 'Chart';
 	public $chart_meta_fields = [

--- a/components/templates/chartjs-chart.php
+++ b/components/templates/chartjs-chart.php
@@ -152,7 +152,7 @@ $iframe_nonce = m_chart()->iframe_csp_nonce ?? '';
 	( () => {
 		const postId    = <?php echo absint( $post_id ); ?>;
 		const instance  = <?php echo absint( $this->instance ); ?>;
-		const chartArgs = <?php echo $this->unicode_aware_stripslashes( json_encode( $this->library( 'chartjs' )->get_chart_args( $post_id, $args ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT ) ); ?>;
+		const chartArgs = <?php echo json_encode( $this->library( 'chartjs' )->get_chart_args( $post_id, $args ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT ); ?>;
 		const canvas    = document.getElementById( 'm-chart-' + postId + '-' + instance ).getContext( '2d' );
 		<?php do_action( 'm_chart_after_chart_args', $post_id, $args, $this->instance ); ?>
 

--- a/m-chart.php
+++ b/m-chart.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: M Chart
-Version: 2.2.1
+Version: 2.2.2
 Plugin URI: https://github.com/methnen/m-chart
 Description: Manage data sets via a spreadsheet interface, display them as charts via the Chart.js chart library, and embed them via a shortcode or block.
 Author: Jamie Poitra

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,12 @@ To contribute, report issues, or make feature requests use [Github](https://gith
 
 == Changelog ==
 
+= 2.2.2 =
+
+* Added a new m_chart_admin_initial_chart_args filter so extensions can modify or replace the chart args used for the editor's initial preview render
+* Fixed an issue where titles, subtitles, and axis titles containing an apostrophe or quote could show a stray backslash on the chart
+	* Removed some legacy slash-escaping left over from the pre-2.0 rendering stack and tightened up the JSON encoding of chart args along the way
+
 = 2.2.1 =
 
 * Improved the accessibility of the source attribution

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: methnen
 Tags: chartjs, graphs, charts, tables, data
 Requires PHP: 8.1
 Tested up to: 7.0
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 License: MIT
 
 Manage data sets via a spreadsheet interface, display them as charts via the Chart.js chart library, and embed them via a shortcode or block.
@@ -57,8 +57,7 @@ To contribute, report issues, or make feature requests use [Github](https://gith
 = 2.2.2 =
 
 * Added a new m_chart_admin_initial_chart_args filter so extensions can modify or replace the chart args used for the editor's initial preview render
-* Fixed an issue where titles, subtitles, and axis titles containing an apostrophe or quote could show a stray backslash on the chart
-	* Removed some legacy slash-escaping left over from the pre-2.0 rendering stack and tightened up the JSON encoding of chart args along the way
+* Removed some legacy slash-escaping left over from the pre-2.0 rendering stack and tightened up the JSON encoding of chart args along the way
 
 = 2.2.1 =
 


### PR DESCRIPTION
* Added a new m_chart_admin_initial_chart_args filter so extensions can modify or replace the chart args used for the editor's initial preview render
* Removed some legacy slash-escaping left over from the pre-2.0 rendering stack and tightened up the JSON encoding of chart args along the way